### PR TITLE
Ignore C4244 warnings to fix VS2012 compilation

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -27,7 +27,8 @@
           },
           'msvs_disabled_warnings': [
             4018,  # signed/unsigned mismatch
-            4267,  # conversion from 'size_t' to 'int', possible loss of data
+            4244,  # conversion from 'type1' to 'type2', possible loss of data
+            4267,  # conversion from 'size_t' to 'type', possible loss of data
             4530,  # C++ exception handler used, but unwind semantics are not enabled
             4506,  # no definition for inline function
             4996,  # function was declared deprecated


### PR DESCRIPTION
As discussed in #19.
