### PR TITLE
Call uv_unref(&g_async) to allow process to exit.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -47,7 +47,7 @@ module.exports = (grunt) ->
           failOnError: true
 
       test:
-        command: 'node --harmony-collections node_modules/jasmine-tagged/bin/jasmine-tagged --captureExceptions --forceexit --coffee spec/'
+        command: 'node --harmony-collections node_modules/jasmine-tagged/bin/jasmine-tagged --captureExceptions --coffee spec/'
         options:
           stdout: true
           stderr: true


### PR DESCRIPTION
This is a better way of fixing #47, since it avoids the extra work of calling `uv_close` and reuses existing libuv APIs (`uv_ref` and `uv_unref`).

I also took the liberty of removing the `--forceexit` option from the test command, now that `g_async` no longer prevents test processes from exiting.

This partially reverts commit c6ddf18, "Call uv_async_init lazily to avoid keeping process alive."
