### PR TITLE
Expose kevent/inotify errnos on thrown error

### DIFF
--- a/spec/pathwatcher-spec.coffee
+++ b/spec/pathwatcher-spec.coffee
@@ -114,6 +114,20 @@ describe 'PathWatcher', ->
           done()
       fs.writeFileSync(tempFile, 'changed')
 
+  describe 'when watching a file that does not exist', ->
+    it 'throws an error with a code', ->
+      doesNotExist = path.join(tempDir, 'does-not-exist')
+      watcher = null
+      try
+        watcher = pathWatcher.watch doesNotExist, -> null
+      catch e
+        expect(e.message).toBe 'Unable to watch path'
+        expect(e.errno).toBe require('constants').ENOENT
+        if process.version.match /^v0\.1[12]/
+          expect(e.code).toBe 'ENOENT'
+      expect(watcher).toBe null  # ensure it threw
+
+
   describe 'when watching multiple files under the same directory', ->
     it 'fires the callbacks when both of the files are modifiled', ->
       called = 0

--- a/src/common.h
+++ b/src/common.h
@@ -27,6 +27,7 @@ void PlatformThread();
 WatcherHandle PlatformWatch(const char* path);
 void PlatformUnwatch(WatcherHandle handle);
 bool PlatformIsHandleValid(WatcherHandle handle);
+int PlatformInvalidHandleToErrorNumber(WatcherHandle handle);
 
 enum EVENT_TYPE {
   EVENT_NONE,

--- a/src/pathwatcher_win.cc
+++ b/src/pathwatcher_win.cc
@@ -300,3 +300,8 @@ void PlatformUnwatch(WatcherHandle key) {
 bool PlatformIsHandleValid(WatcherHandle handle) {
   return handle != INVALID_HANDLE_VALUE;
 }
+
+// We have no errno on Windows.
+int PlatformInvalidHandleToErrorNumber(WatcherHandle handle) {
+  return 0;
+}


### PR DESCRIPTION
The error will have a numeric 'code', which is the system errno
value (NOT the uv errno value).

(I spent quite a while trying to convert this into a string like `'ENOENT'` but uv actually makes that hard by not exposing their internal errno conversion API (https://github.com/libuv/libuv/issues/79); and posix only gives you `strerror` which gets you the English description rather than the short string.)

This change also stops it from being a TypeError, which seems reasonable... makes sense to use NaNThrowTypeError for "String required" but not for "syscall failed".

This change also ensures that if the initial inotify/kqueue init syscall failed, we make Watch calls fail immediately instead of trying to call the follow-up call.