### PR TITLE
Add specific resurrect event handling for resurrection

### DIFF
--- a/spec/file-spec.coffee
+++ b/spec/file-spec.coffee
@@ -173,6 +173,7 @@ describe 'File', ->
           runs ->
             args = errorSpy.mostRecentCall.args[0]
             expect(args.error.code).toBe 'ENOENT'
+            expect(args.error.eventType).toBe 'change'
             expect(args.handle).toBeTruthy()
 
       describe "when the error happens in the read method", ->
@@ -193,6 +194,7 @@ describe 'File', ->
           runs ->
             args = errorSpy.mostRecentCall.args[0]
             expect(args.error.code).toBe 'ENOENT'
+            expect(args.error.eventType).toBe 'change'
             expect(args.handle).toBeTruthy()
 
   describe "getRealPathSync()", ->

--- a/spec/file-spec.coffee
+++ b/spec/file-spec.coffee
@@ -162,7 +162,7 @@ describe 'File', ->
             error.code = 'ENOENT'
             throw error
 
-        it "emits an event with the error when the error happens in the promise callback chain", ->
+        it "emits an event with the error", ->
           changeHandler = jasmine.createSpy('changeHandler')
           file.onDidChange changeHandler
           fs.writeFileSync(file.getPath(), "this is new!!")
@@ -183,7 +183,7 @@ describe 'File', ->
             error.code = 'ENOENT'
             throw error
 
-        it "emits an event with the error when the error happens in the promise callback chain", ->
+        it "emits an event with the error", ->
           changeHandler = jasmine.createSpy('changeHandler')
           file.onDidChange changeHandler
           fs.writeFileSync(file.getPath(), "this is new!!")

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -288,7 +288,7 @@ class File
         @setPath(eventPath)
         @emit 'moved'
         @emitter.emit 'did-rename'
-      when 'change'
+      when 'change', 'resurrect'
         oldContents = @cachedContents
         handleReadError = (error) =>
           # We cant read the file, so we GTFO on the watch
@@ -298,7 +298,7 @@ class File
           handle = -> handled = true
           @emitter.emit('will-throw-watch-error', {error, handle})
           unless handled
-            newError = new Error("Cannot read file after file change event: #{@path}")
+            newError = new Error("Cannot read file after file `#{eventType}` event: #{@path}")
             newError.originalError = error
             newError.code = "ENOENT"
             newError.path
@@ -321,7 +321,7 @@ class File
   detectResurrection: ->
     if @exists()
       @subscribeToNativeChangeEvents()
-      @handleNativeChangeEvent('change', @getPath())
+      @handleNativeChangeEvent('resurrect', @getPath())
     else
       @cachedContents = null
       @emit 'removed'

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -296,6 +296,7 @@ class File
 
           handled = false
           handle = -> handled = true
+          error.eventType = eventType
           @emitter.emit('will-throw-watch-error', {error, handle})
           unless handled
             newError = new Error("Cannot read file after file `#{eventType}` event: #{@path}")


### PR DESCRIPTION
People are getting `ENOENT open` errors when they change branches and a watched file does not exist on the switched-to branch: https://github.com/atom/atom/issues/4850

Pathwatcher is emitting a `change` event sometime after the file is deleted, and it cannot read the file again. [this line](https://github.com/atom/node-pathwatcher/blob/8417d3d4b96bd8520c569cf9df3ca0bde83547b0/src/file.coffee#L311) is failing.

[This line](https://github.com/atom/node-pathwatcher/blob/8417d3d4b96bd8520c569cf9df3ca0bde83547b0/src/file.coffee#L318) is suspicious as well because it fires a change event on it's own after a delay. 

This PR separates the real change event originating in the native code from the resurrection change event. When this comes up again, the event type will be in the error message, and we will know for sure who is triggering the error.
