### PR TITLE
Change File methods to do more with async node API wrapped with Q promises

### DIFF
--- a/spec/directory-spec.coffee
+++ b/spec/directory-spec.coffee
@@ -238,11 +238,7 @@ describe "Directory", ->
         it "doesn't have to actually exist", ->
           f = directory.getFile("the-silver-bullet")
           expect(f.isFile()).toBe(true)
-          expect(f.exists()).toBe(false)
-
-        it "does fail if you give it a directory though", ->
-          tryit = -> directory.getFile("subdir")
-          expect(tryit).toThrow()
+          expect(f.existsSync()).toBe(false)
 
       describe "getSubdir(dirname)", ->
         it "returns a subdirectory within this directory", ->

--- a/spec/file-spec.coffee
+++ b/spec/file-spec.coffee
@@ -321,7 +321,13 @@ describe 'File', ->
 
     it 'should write a file in UTF-16', ->
       file.setEncoding('utf16le')
-      file.write(unicodeText).then ->
+      writeHandler = jasmine.createSpy('write handler')
+      file.write(unicodeText).then(writeHandler)
+
+      waitsFor 'write handler', ->
+        writeHandler.callCount > 0
+
+      runs ->
         expect(fs.statSync(file.getPath()).size).toBe(2)
         content = fs.readFileSync(file.getPath()).toString('ascii')
         expect(content).toBe(unicodeBytes.toString('ascii'))

--- a/spec/file-spec.coffee
+++ b/spec/file-spec.coffee
@@ -323,11 +323,19 @@ describe 'File', ->
       file.setEncoding('utf16le')
       writeHandler = jasmine.createSpy('write handler')
       file.write(unicodeText).then(writeHandler)
-
       waitsFor 'write handler', ->
         writeHandler.callCount > 0
-
       runs ->
         expect(fs.statSync(file.getPath()).size).toBe(2)
         content = fs.readFileSync(file.getPath()).toString('ascii')
         expect(content).toBe(unicodeBytes.toString('ascii'))
+
+  describe 'reading a non-existing file', ->
+    it 'should return null', ->
+      file = new File('not_existing.txt')
+      readHandler = jasmine.createSpy('read handler')
+      file.read().then(readHandler)
+      waitsFor 'read handler', ->
+        readHandler.callCount > 0
+      runs ->
+        expect(readHandler.argsForCall[0][0]).toBe(null)

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -148,7 +148,7 @@ class File
   #
   # Returns a {String}.
   getDigestSync: ->
-    contents = @readSync()
+    @readSync()
     # read sets digest
     @digest
 
@@ -184,7 +184,7 @@ class File
         @realPath = @path
     @realPath
 
-  # Public: Returns this file's completely resolved {String} path.
+  # Public: Returns a promise that resolves to the file's completely resolved {String} path.
   getRealPath: ->
     if @realPath?
       Q.resolve @realPath

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -126,7 +126,7 @@ class File
   # Public: Returns a {Boolean}, always false.
   isDirectory: -> false
 
-  # Public: Returns a {Boolean}, true if the file exists, false otherwise.
+  # Returns a promise that resolves to a {Boolean}, true if the file exists, false otherwise.
   exists: ->
     Q.Promise (resolve, reject) =>
       fs.exists @getPath(), resolve
@@ -187,7 +187,7 @@ class File
   # Public: Returns a promise that resolves to the file's completely resolved {String} path.
   getRealPath: ->
     if @realPath?
-      Q.resolve @realPath
+      Q(@realPath)
     else
       Q.nfcall(fs.realpath, @path).then (realPath) =>
         @realPath = realPath

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -130,9 +130,8 @@ class File
 
   # Public: Returns a {Boolean}, true if the file exists, false otherwise.
   exists: ->
-    deferred = Q.defer()
-    fs.exists('/tmp', deferred.resolve); 
-    deferred.promise
+    Q.Promise (resolve, reject) =>
+      fs.exists @getPath(), resolve
 
   # Public: Returns a {Boolean}, true if the file exists, false otherwise.
   existsSync: ->
@@ -352,7 +351,7 @@ class File
 
   detectResurrection: ->
     @exists().then (exists) =>
-      if (exists)
+      if exists
         @subscribeToNativeChangeEvents()
         @handleNativeChangeEvent('resurrect', @getPath())
       else

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -101,8 +101,7 @@ class File
     @emitter.on('will-throw-watch-error', callback)
 
   willAddSubscription: =>
-    if @subscriptionCount++ > 0
-      return
+    return if @subscriptionCount++ > 0
     try
       @subscribeToNativeChangeEvents()
     catch
@@ -287,7 +286,7 @@ class File
         @subscribeToNativeChangeEvents() if not previouslyExisted and @hasSubscriptions()
         undefined
 
-  writeFile: (filePath, text) ->
+  writeFile: (filePath, contents) ->
     encoding = @getEncoding()
     if encoding is 'utf8'
       Q.nfcall(fs.writeFile(filePath, contents, {encoding}))


### PR DESCRIPTION
Having more async IO will be the initial effort to support remote filesystem
Here, the code introduces some optimizations to reduce the number of filesystem calls and assumes:
* Synchronous functions are being deprecated
* Q promises are the standard way of code in Atom (I think promises are good in the case a future decision was taken to introduce the await / async syntactic sugar of JS ES6/7)

Some other PRs are following with the same approach