### PR TITLE
Bump emissary

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "async": "~0.2.10",
-    "emissary": "^1.1.0",
+    "emissary": "^1.3.2",
     "event-kit": "^1.0.0",
     "fs-plus": "^2.1",
     "grim": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "async": "~0.2.10",
-    "emissary": "^1.3.2",
+    "emissary": "^1.1.0",
     "event-kit": "^1.0.0",
     "fs-plus": "^2.1",
     "grim": "^1.0.0",


### PR DESCRIPTION
Meteor.js depends on node-pathwatcher and there was a bug in one of emissary dependants, so it would be nice, if you merge it, and I could update meteor.
Bug: https://github.com/mquandalle/meteor-harmony/issues/37#issuecomment-73725823