### PR TITLE
Add Directory.existsSync() (in preparation for bump to v3.2.1).

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "./lib/main.js",
   "name": "pathwatcher",
   "description": "Watch files and directories for changes",
-  "version": "3.1.1",
+  "version": "3.1.0",
   "licenses": [
     {
       "type": "MIT",
@@ -41,7 +41,7 @@
     "grim": "^1.0.0",
     "iconv-lite": "~0.4.4",
     "nan": "https://atom.io/download/atom-shell/nan-1.6.1.tgz",
-    "q": "^1.1.2",
+    "q": "~1.0.1",
     "runas": "^2.0.0",
     "underscore-plus": "~1.x"
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "./lib/main.js",
   "name": "pathwatcher",
   "description": "Watch files and directories for changes",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "licenses": [
     {
       "type": "MIT",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "grim": "^1.0.0",
     "iconv-lite": "~0.4.4",
     "nan": "https://atom.io/download/atom-shell/nan-1.6.1.tgz",
-    "q": "~1.0.1",
+    "q": "^1.1.2",
     "runas": "^2.0.0",
     "underscore-plus": "~1.x"
   }

--- a/src/directory.coffee
+++ b/src/directory.coffee
@@ -83,6 +83,10 @@ class Directory
   # Public: Returns a {Boolean}, always true.
   isDirectory: -> true
 
+  # Public: Returns a {Boolean}, true if the file exists, false otherwise.
+  existsSync: ->
+    fs.existsSync(@getPath())
+
   # Public: Return a {Boolean}, true if this {Directory} is the root directory
   # of the filesystem, or false if it isn't.
   isRoot: ->


### PR DESCRIPTION
`Directory.existsSync()` is also introduced in `v4.0.0`, but it's hard to
upgrade Atom core to `pathwatcher@4.0.0` because it changes `File.exists()`
to be async instead of sync. This will be a useful upgrade to Atom core
so the TODO in `git-repository-provider.coffee` in `directoryExistsSync()`
can be fixed: https://github.com/atom/atom/commit/e04f17fe5f9677b9f6f50520449baee5a24eaeff.