### PR TITLE
Add Directory.existsSync() (in preparation for bump to v3.2.1).

### DIFF
--- a/spec/directory-spec.coffee
+++ b/spec/directory-spec.coffee
@@ -33,6 +33,10 @@ describe "Directory", ->
   it 'returns true from isDirectory()', ->
     expect(directory.isDirectory()).toBe true
 
+  describe "existsSync()", ->
+    it "returns true if the directory exists", ->
+      expect(directory.existsSync()).toBe true
+
   describe "when the contents of the directory change on disk", ->
     temporaryFilePath = null
 

--- a/src/directory.coffee
+++ b/src/directory.coffee
@@ -83,7 +83,7 @@ class Directory
   # Public: Returns a {Boolean}, always true.
   isDirectory: -> true
 
-  # Public: Returns a {Boolean}, true if the file exists, false otherwise.
+  # Public: Returns a {Boolean}, true if the directory exists, false otherwise.
   existsSync: ->
     fs.existsSync(@getPath())
 

--- a/src/directory.coffee
+++ b/src/directory.coffee
@@ -83,6 +83,10 @@ class Directory
   # Public: Returns a {Boolean}, always true.
   isDirectory: -> true
 
+  # Public: Returns a {Boolean}, true if the file exists, false otherwise.
+  existsSync: ->
+    fs.existsSync(@getPath())
+
   # Public: Return a {Boolean}, true if this {Directory} is the root directory
   # of the filesystem, or false if it isn't.
   isRoot: ->


### PR DESCRIPTION
`Directory.existsSync()` is also introduced in v4, but it's hard to
upgrade Atom core to `pathwatcher@4.0.0` because it changes `File.exists()`
to be async instead of sync. This will be a useful upgrade to Atom core
so the TODO in `git-repository-provider.coffee` in `directoryExistsSync()`
can be fixed: https://github.com/atom/atom/commit/e04f17fe5f9677b9f6f50520449baee5a24eaeff.