### PR TITLE
Implement File::writeSync().

### DIFF
--- a/spec/file-spec.coffee
+++ b/spec/file-spec.coffee
@@ -330,6 +330,13 @@ describe 'File', ->
         content = fs.readFileSync(file.getPath()).toString('ascii')
         expect(content).toBe(unicodeBytes.toString('ascii'))
 
+    it 'should write a file in UTF-16 synchronously', ->
+      file.setEncoding('utf16le')
+      file.writeSync(unicodeText)
+      expect(fs.statSync(file.getPath()).size).toBe(2)
+      content = fs.readFileSync(file.getPath()).toString('ascii')
+      expect(content).toBe(unicodeBytes.toString('ascii'))
+
   describe 'reading a non-existing file', ->
     it 'should return null', ->
       file = new File('not_existing.txt')

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -274,13 +274,25 @@ class File
   #
   # * `text` The {String} text to write to the underlying file.
   #
-  # Return undefined.
+  # Returns a {Promise} that resolves when the file has been written.
   write: (text) ->
     @exists().then (previouslyExisted) =>
       @writeFile(@getPath(), text).then =>
         @cachedContents = text
         @subscribeToNativeChangeEvents() if not previouslyExisted and @hasSubscriptions()
         undefined
+
+  # Public: Overwrites the file with the given text.
+  #
+  # * `text` The {String} text to write to the underlying file.
+  #
+  # Return undefined.
+  writeSync: (text) ->
+    previouslyExisted = @exists()
+    @writeFileWithPrivilegeEscalationSync(@getPath(), text)
+    @cachedContents = text
+    @subscribeToNativeChangeEvents() if not previouslyExisted and @hasSubscriptions()
+    undefined
 
   writeFile: (filePath, contents) ->
     encoding = @getEncoding()


### PR DESCRIPTION
Use old implementation of `File::write()` back when it was synchronous:
https://github.com/atom/node-pathwatcher/commit/88fe3219b736bcb6510f73ecb7fd053187132d87