### PR TITLE
Introduce File::writeSync() as an alternative to File::write().

### DIFF
--- a/spec/file-spec.coffee
+++ b/spec/file-spec.coffee
@@ -270,7 +270,7 @@ describe 'File', ->
 
     it 'should write a file in UTF-16', ->
       file.setEncoding('utf16le')
-      file.write(unicodeText)
+      file.writeSync(unicodeText)
 
       expect(fs.statSync(file.getPath()).size).toBe(2)
       content = fs.readFileSync(file.getPath()).toString('ascii')

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -260,6 +260,15 @@ class File
   #
   # Return undefined.
   write: (text) ->
+    Grim.deprecate("Use File::writeSync instead")
+    @writeSync(text)
+
+  # Public: Overwrites the file with the given text.
+  #
+  # * `text` The {String} text to write to the underlying file.
+  #
+  # Return undefined.
+  writeSync: (text) ->
     previouslyExisted = @existsSync()
     @writeFileWithPrivilegeEscalationSync(@getPath(), text)
     @cachedContents = text


### PR DESCRIPTION
Once this is submitted:

* A new release of `node-pathwatcher` 3.x needs to be made.
* https://github.com/atom/text-buffer needs to pick up the new version of `node-pathwatcher` 3.x and replace its use of `file.write()` with `file.writeSync()`.
* Then `File::writeSync()` needs to be added to the 4.x branch via https://github.com/atom/node-pathwatcher/pull/64.
* Once that is done, https://github.com/atom/text-buffer should be able to pick up the new version of `node-pathwatcher` 4.x via https://github.com/atom/text-buffer/pull/51.
* This should ultimately unblock upgrading to `node-pathwatcher` 4.x across all of Atom: https://github.com/atom/atom/issues/5706.