### PR TITLE
Add getters for File/Directory symlink property

### DIFF
--- a/spec/directory-spec.coffee
+++ b/spec/directory-spec.coffee
@@ -32,6 +32,15 @@ describe "Directory", ->
   it 'returns true from isDirectory()', ->
     expect(directory.isDirectory()).toBe true
 
+  describe '::isSymbolicLink()', ->
+
+    it 'returns false for regular directories', ->
+      expect(directory.isSymbolicLink()).toBe false
+
+    it 'returns true for symlinked directories', ->
+      directorySym = new Directory(path.join(__dirname, 'fixtures'), true)
+      expect(directorySym.isSymbolicLink()).toBe true
+
   describe '::exists()', ->
     [callback, tempDir] = []
 
@@ -208,9 +217,9 @@ describe "Directory", ->
         for entry in entries
           name = entry.getBaseName()
           if name is 'symlink-to-dir' or name is 'symlink-to-file'
-            expect(entry.symlink).toBeTruthy()
+            expect(entry.isSymbolicLink()).toBe true
           else
-            expect(entry.symlink).toBeFalsy()
+            expect(entry.isSymbolicLink()).toBe false
 
   describe ".relativize(path)", ->
     describe "on #darwin or #linux", ->

--- a/spec/directory-spec.coffee
+++ b/spec/directory-spec.coffee
@@ -33,13 +33,12 @@ describe "Directory", ->
     expect(directory.isDirectory()).toBe true
 
   describe '::isSymbolicLink()', ->
-
     it 'returns false for regular directories', ->
       expect(directory.isSymbolicLink()).toBe false
 
     it 'returns true for symlinked directories', ->
-      directorySym = new Directory(path.join(__dirname, 'fixtures'), true)
-      expect(directorySym.isSymbolicLink()).toBe true
+      symbolicDirectory = new Directory(path.join(__dirname, 'fixtures'), true)
+      expect(symbolicDirectory.isSymbolicLink()).toBe true
 
   describe '::exists()', ->
     [callback, tempDir] = []

--- a/spec/file-spec.coffee
+++ b/spec/file-spec.coffee
@@ -28,6 +28,15 @@ describe 'File', ->
   it 'returns false from isDirectory()', ->
     expect(file.isDirectory()).toBe false
 
+  describe '::isSymbolicLink', ->
+
+    it 'returns false for regular files', ->
+      expect(file.isSymbolicLink()).toBe false
+
+    it 'returns true for symlinked files', ->
+      symFile = new File(filePath, true)
+      expect(symFile.isSymbolicLink()).toBe true
+
   describe "::getDigestSync", ->
     it "computes and returns the SHA-1 digest and caches it", ->
       filePath = path.join(temp.mkdirSync('node-pathwatcher-directory'), 'file.txt')

--- a/spec/file-spec.coffee
+++ b/spec/file-spec.coffee
@@ -29,13 +29,12 @@ describe 'File', ->
     expect(file.isDirectory()).toBe false
 
   describe '::isSymbolicLink', ->
-
     it 'returns false for regular files', ->
       expect(file.isSymbolicLink()).toBe false
 
     it 'returns true for symlinked files', ->
-      symFile = new File(filePath, true)
-      expect(symFile.isSymbolicLink()).toBe true
+      symbolicFile = new File(filePath, true)
+      expect(symbolicFile.isSymbolicLink()).toBe true
 
   describe "::getDigestSync", ->
     it "computes and returns the SHA-1 digest and caches it", ->

--- a/src/directory.coffee
+++ b/src/directory.coffee
@@ -16,6 +16,13 @@ class Directory
   subscriptionCount: 0
 
   ###
+  Section: Properties
+  ###
+
+  # Public: A {boolean} indicating whether or not this is a symlink
+  symlink: null
+
+  ###
   Section: Construction
   ###
 

--- a/src/directory.coffee
+++ b/src/directory.coffee
@@ -16,13 +16,6 @@ class Directory
   subscriptionCount: 0
 
   ###
-  Section: Properties
-  ###
-
-  # Public: A {boolean} indicating whether or not this is a symlink
-  symlink: null
-
-  ###
   Section: Construction
   ###
 
@@ -103,6 +96,10 @@ class Directory
 
   # Public: Returns a {Boolean}, always true.
   isDirectory: -> true
+
+  # Public: Returns a {Boolean} indicating whether or not this is a symbolic link
+  isSymbolicLink: ->
+    @symlink
 
   # Public: Returns a promise that resolves to a {Boolean}, true if the
   # directory exists, false otherwise.

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -22,13 +22,6 @@ class File
   subscriptionCount: 0
 
   ###
-  Section: Properties
-  ###
-
-  # Public: A {boolean} indicating whether or not this is a symlink
-  symlink: null
-
-  ###
   Section: Construction
   ###
 
@@ -133,6 +126,10 @@ class File
 
   # Public: Returns a {Boolean}, always false.
   isDirectory: -> false
+
+  # Public: Returns a {Boolean} indicating whether or not this is a symbolic link
+  isSymbolicLink: ->
+    @symlink
 
   # Public: Returns a promise that resolves to a {Boolean}, true if the file
   # exists, false otherwise.

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -22,6 +22,13 @@ class File
   subscriptionCount: 0
 
   ###
+  Section: Properties
+  ###
+
+  # Public: A {boolean} indicating whether or not this is a symlink
+  symlink: null
+
+  ###
   Section: Construction
   ###
 


### PR DESCRIPTION
`@symlink` is assigned in the constructors of `File` and `Directory`,
but the property is currently undocumented. Add an instance property and
appropriate documentation.