### PR TITLE
Use native promises instead of Q library

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "./lib/main.js",
   "name": "pathwatcher",
   "description": "Watch files and directories for changes",
-  "version": "4.4.3",
+  "version": "5.0.0",
   "licenses": [
     {
       "type": "MIT",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "grim": "^1.2.1",
     "iconv-lite": "~0.4.4",
     "nan": "https://atom.io/download/atom-shell/nan-1.6.1.tgz",
-    "q": "^1.1.2",
     "runas": "^2.0.0",
     "underscore-plus": "~1.x"
   }

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
 
-echo "Downloading node v0.10.22..."
-curl -s -O http://nodejs.org/dist/v0.10.22/node-v0.10.22-darwin-x64.tar.gz
-tar -zxf node-v0.10.22-darwin-x64.tar.gz
-export PATH=$PATH:$PWD/node-v0.10.22-darwin-x64/bin
+echo "Downloading node v0.12.7..."
+curl -s -O http://nodejs.org/dist/v0.12.7/node-v0.12.7-darwin-x64.tar.gz
+tar -zxf node-v0.12.7-darwin-x64.tar.gz
+export PATH=$PWD/node-v0.12.7-darwin-x64/bin:$PATH
 
 npm install
 npm test

--- a/src/directory.coffee
+++ b/src/directory.coffee
@@ -4,7 +4,6 @@ async = require 'async'
 {Emitter, Disposable} = require 'event-kit'
 fs = require 'fs-plus'
 Grim = require 'grim'
-Q = require 'q'
 
 File = require './file'
 PathWatcher = require './main'
@@ -55,7 +54,7 @@ class Directory
       throw Error("Root directory does not exist: #{@getPath()}") if @isRoot()
 
       @getParent().create().then =>
-        Q.Promise (resolve, reject) =>
+        new Promise (resolve, reject) =>
           fs.mkdir @getPath(), mode, (error) ->
             if error
               reject error
@@ -104,8 +103,7 @@ class Directory
   # Public: Returns a promise that resolves to a {Boolean}, true if the
   # directory exists, false otherwise.
   exists: ->
-    Q.Promise (resolve, reject) =>
-      fs.exists(@getPath(), resolve)
+    new Promise (resolve) => fs.exists(@getPath(), resolve)
 
   # Public: Returns a {Boolean}, true if the directory exists, false otherwise.
   existsSync: ->


### PR DESCRIPTION
Now that native promises work in Electron, there's no reason to continue using the Q library. Its API is nonstandard and it seems to swallow errors in unpredictable ways.

Since the API of Q's promises differs slightly from native promises, this requires a major version increment.

/cc @kevinsawicki since you've done a lot with pathwatcher.