### PR TITLE
Windows and VS2015: add 4577 to the disabled warnings

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -31,7 +31,7 @@
             4267,  # conversion from 'size_t' to 'type', possible loss of data
             4530,  # C++ exception handler used, but unwind semantics are not enabled
             4506,  # no definition for inline function
-			4577,  # 'noexcept' used with no exception handling mode specified; termination on exception is not guaranteed
+            4577,  # 'noexcept' used with no exception handling mode specified; termination on exception is not guaranteed
             4996,  # function was declared deprecated
           ],
           'defines': [

--- a/binding.gyp
+++ b/binding.gyp
@@ -31,6 +31,7 @@
             4267,  # conversion from 'size_t' to 'type', possible loss of data
             4530,  # C++ exception handler used, but unwind semantics are not enabled
             4506,  # no definition for inline function
+			4577,  # 'noexcept' used with no exception handling mode specified; termination on exception is not guaranteed
             4996,  # function was declared deprecated
           ],
           'defines': [


### PR DESCRIPTION
I tried to build with VS 2015 and failed because of this warning.
Maybe there are better fix but at least with this patch I was able to build.