### PR TITLE
Add linebreak for Directory::create return val

### DIFF
--- a/src/directory.coffee
+++ b/src/directory.coffee
@@ -43,7 +43,8 @@ class Directory
   # Public: Creates the directory on disk that corresponds to `::getPath()` if
   # no such directory already exists.
   #
-  # * `mode` Optional {Number} that defaults to `0777`.
+  # * `mode` (optional) {Number} that defaults to `0777`.
+  #
   # Returns a {Promise} that resolves once the directory is created on disk. It
   # resolves to a boolean value that is true if the directory was created or
   # false if it already existed.


### PR DESCRIPTION
`Returns` must be separated by a blank line in order to be parsed
correctly for the generated documentation.

v1.0.11 [`Directory::create`](https://atom.io/docs/api/v1.0.11/Directory#instance-create) rendering does not split the return value nor mark `mode` as optional:
<img width="614" alt="screen shot 2015-09-03 at 9 13 20 am" src="https://cloud.githubusercontent.com/assets/29612/9663997/23af92f4-521c-11e5-827a-b64eef361ca7.png">
