### PR TITLE
Switch travis.yml to use nodejs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ node_js:
   - "0.12"
   - "node"
 
+env:
+  - CC=clang CXX=clang++ npm_config_clang=1
+
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ node_js:
   - "node"
 
 env:
-  - CC=gcc CXX=g++
+  - CC=gcc-4.8 CXX=g++-4.8
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ node_js:
   - "node"
 
 env:
-  - CC=clang CXX=clang++ npm_config_clang=1
+  - CC=gcc CXX=g++
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
-language: objective-c
+language: node_js
 
 notifications:
   email:
     on_success: never
     on_failure: change
 
-script: ./script/cibuild
+sudo: false
 
 git:
   depth: 10
+
+node_js:
+  - "0.12"
+  - "node"
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: node_js
 
-notifications:
-  email:
-    on_success: never
-    on_failure: change
-
 sudo: false
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
 
 git:
   depth: 10
@@ -20,3 +22,8 @@ env:
 branches:
   only:
     - master
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,9 +1,0 @@
-#!/usr/bin/env sh
-
-echo "Downloading node v0.12.7..."
-curl -s -O http://nodejs.org/dist/v0.12.7/node-v0.12.7-darwin-x64.tar.gz
-tar -zxf node-v0.12.7-darwin-x64.tar.gz
-export PATH=$PWD/node-v0.12.7-darwin-x64/bin:$PATH
-
-npm install
-npm test


### PR DESCRIPTION
Just investigating if pathwatcher actually builds on Node 4.
Refs atom/text-buffer#99.