### PR TITLE
Use Local instead of Handle

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -11,9 +11,9 @@ using namespace v8;
 typedef HANDLE WatcherHandle;
 
 // Conversion between V8 value and WatcherHandle.
-Handle<Value> WatcherHandleToV8Value(WatcherHandle handle);
-WatcherHandle V8ValueToWatcherHandle(Handle<Value> value);
-bool IsV8ValueWatcherHandle(Handle<Value> value);
+Local<Value> WatcherHandleToV8Value(WatcherHandle handle);
+WatcherHandle V8ValueToWatcherHandle(Local<Value> value);
+bool IsV8ValueWatcherHandle(Local<Value> value);
 #else
 // Correspoding definetions on OS X and Linux.
 typedef int32_t WatcherHandle;

--- a/src/pathwatcher_win.cc
+++ b/src/pathwatcher_win.cc
@@ -96,18 +96,18 @@ static bool QueueReaddirchanges(HandleWrapper* handle) {
                                NULL) == TRUE;
 }
 
-Handle<Value> WatcherHandleToV8Value(WatcherHandle handle) {
-  Handle<Value> value = Nan::New(g_object_template)->NewInstance();
+Local<Value> WatcherHandleToV8Value(WatcherHandle handle) {
+  Local<Value> value = Nan::New(g_object_template)->NewInstance();
   Nan::SetInternalFieldPointer(value->ToObject(), 0, handle);
   return value;
 }
 
-WatcherHandle V8ValueToWatcherHandle(Handle<Value> value) {
+WatcherHandle V8ValueToWatcherHandle(Local<Value> value) {
   return reinterpret_cast<WatcherHandle>(Nan::GetInternalFieldPointer(
       value->ToObject(), 0));
 }
 
-bool IsV8ValueWatcherHandle(Handle<Value> value) {
+bool IsV8ValueWatcherHandle(Local<Value> value) {
   return value->IsObject() && value->ToObject()->InternalFieldCount() == 1;
 }
 


### PR DESCRIPTION
Handle are deprecated in favor of Local.
This should fix https://github.com/atom/node-pathwatcher/issues/96

A clean `npm install`, on my pc, always fail but the subsequent run works fine.
And without the patch cannot build on Windows, with I can: so I hope this is enough.