### PR TITLE
Feature file stream

### DIFF
--- a/spec/file-spec.coffee
+++ b/spec/file-spec.coffee
@@ -417,6 +417,26 @@ describe 'File', ->
       runs ->
         expect(content.join('')).toEqual(unicodeText)
 
+  describe 'createWriteStream()', ->
+    it 'returns a stream to read the file', ->
+      unicodeText = 'ё'
+      unicodeBytes = new Buffer('\x51\x04') # 'ё'
+
+      file.setEncoding('utf16le')
+      stream = file.createWriteStream()
+      ended = false
+
+      stream.on 'finish', -> ended = true
+
+      stream.end(unicodeText)
+
+      waitsFor 'stream finished', -> ended
+
+      runs ->
+        expect(fs.statSync(file.getPath()).size).toBe(2)
+        content = fs.readFileSync(file.getPath()).toString('ascii')
+        expect(content).toBe(unicodeBytes.toString('ascii'))
+
   describe 'encoding support', ->
     [unicodeText, unicodeBytes] = []
 

--- a/spec/file-spec.coffee
+++ b/spec/file-spec.coffee
@@ -383,6 +383,40 @@ describe 'File', ->
         file.setEncoding('utf-8-bom')
       ).toThrow()
 
+  describe 'createReadStream()', ->
+    it 'returns a stream to read the file', ->
+      stream = file.createReadStream()
+      ended = false
+      content = []
+
+      stream.on 'data', (chunk) -> content.push(chunk)
+      stream.on 'end', -> ended = true
+
+      waitsFor 'stream ended', -> ended
+
+      runs ->
+        expect(content.join('')).toEqual('this is old!')
+
+    it 'honors the specified encoding', ->
+      unicodeText = 'ё'
+      unicodeBytes = new Buffer('\x51\x04') # 'ё'
+
+      fs.writeFileSync(file.getPath(), unicodeBytes)
+
+      file.setEncoding('utf16le')
+
+      stream = file.createReadStream()
+      ended = false
+      content = []
+
+      stream.on 'data', (chunk) -> content.push(chunk)
+      stream.on 'end', -> ended = true
+
+      waitsFor 'stream ended', -> ended
+
+      runs ->
+        expect(content.join('')).toEqual(unicodeText)
+
   describe 'encoding support', ->
     [unicodeText, unicodeBytes] = []
 

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -281,6 +281,17 @@ class File
       @setDigest(contents)
       @cachedContents = contents
 
+  # Public: Returns a stream to read the content of the file.
+  #
+  # Returns a {ReadStream} object.
+  createReadStream: ->
+    encoding = @getEncoding()
+    if encoding is 'utf8'
+      fs.createReadStream(@getPath(), {encoding})
+    else
+      iconv ?= require 'iconv-lite'
+      fs.createReadStream(@getPath()).pipe(iconv.decodeStream(encoding))
+
   # Public: Overwrites the file with the given text.
   #
   # * `text` The {String} text to write to the underlying file.

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -258,12 +258,7 @@ class File
     else
       promise = new Promise (resolve, reject) =>
         content = []
-        encoding = @getEncoding()
-        if encoding is 'utf8'
-          readStream = fs.createReadStream(@getPath(), {encoding})
-        else
-          iconv ?= require 'iconv-lite'
-          readStream = fs.createReadStream(@getPath()).pipe(iconv.decodeStream(encoding))
+        readStream = @createReadStream()
 
         readStream.on 'data', (chunk) ->
           content.push(chunk)

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -300,6 +300,19 @@ class File
         @subscribeToNativeChangeEvents() if not previouslyExisted and @hasSubscriptions()
         undefined
 
+  # Public: Returns a stream to write content to the file.
+  #
+  # Returns a {WriteStream} object.
+  createWriteStream: ->
+    encoding = @getEncoding()
+    if encoding is 'utf8'
+      fs.createWriteStream(@getPath(), {encoding})
+    else
+      iconv ?= require 'iconv-lite'
+      stream = iconv.encodeStream(encoding)
+      stream.pipe(fs.createWriteStream(@getPath()))
+      stream
+
   # Public: Overwrites the file with the given text.
   #
   # * `text` The {String} text to write to the underlying file.


### PR DESCRIPTION
The `File::read` method is already using a stream to process the file's content with iconv on the fly, but there's no way for the consumer of a `File` to get a read stream for the proper encoding - one can always use the `fs` APIs to get a stream but it has to include `iconv-lite` as dependency if it want to behave the same as the `File` API.

This PR adds a public `createReadStream` method on the `File` object that encapsulates the stream creation that was previously in the `read` method.