### PR TITLE
Emit delete event when file moved to trash on OS X

### DIFF
--- a/spec/file-spec.coffee
+++ b/spec/file-spec.coffee
@@ -231,6 +231,23 @@ describe 'File', ->
         waitsFor "post-resurrection change event", ->
           changeHandler.callCount > 0
 
+    describe "when a file is moved to the trash", ->
+      osxTrashDir = process.env.HOME + "/.Trash"
+      osxTrashPath = path.join(osxTrashDir, "file-was-moved-to-trash.txt")
+      it "triggers a delete event", ->
+        deleteHandler = null
+        deleteHandler = jasmine.createSpy("deleteHandler")
+        file.onDidDelete(deleteHandler)
+
+        fs.moveSync(filePath, osxTrashPath)
+
+        waitsFor "remove event", ->
+          deleteHandler.callCount > 0
+
+        # Clean up
+        if fs.existsSync(osxTrashPath)
+          fs.removeSync(osxTrashPath)
+
     describe "when a file cannot be opened after the watch has been applied", ->
       errorSpy = null
       beforeEach ->

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -26,8 +26,13 @@ class HandleWatcher extends EventEmitter
           fs.stat @path, (err) =>
             if err # original file is gone it's a rename.
               @path = filePath
-              @start()
-              @emit('change', 'rename', filePath)
+              # On OS X files moved to ~/.Trash should be handled as deleted.
+              if process.platform is 'darwin' and (/\/\.Trash\//).test(filePath)
+                @emit('change', 'delete', null)
+                @close()
+              else
+                @start()
+                @emit('change', 'rename', filePath)
             else # atomic write.
               @start()
               @emit('change', 'change', null)


### PR DESCRIPTION
Fixes #104 and subsequently atom/tabs#160, atom/find-and-replace#634, atom/fuzzy-finder#168.
The issue was that `Move To Trash`, which is how `tree-view` deletes items, was not being interpreted as a `delete` event by `HandleWatcher`. 
This PR adds a check in `HandleWatcher` any time a `rename` event is emitted to see if it was a move to a `.Trash` dir. If it was, it emits a `delete` event in stead of a `rename` event to the `PathWatcher`.

A spec is included, but testing can also be done in any of the referenced packages by recreating the steps in the respective issues.

Some questions/room for improvement:
1. Is `HandleWatcher` low enough to be handling this or should it be done in `pathwatcher_unix.cc`?
2. Should the [regular expression](https://github.com/atom/node-pathwatcher/compare/atom:1350d94...anderoonies:4b249d3#diff-4477caae3724b653d6129d656c808b4cR30) be more rigorous (checking `process.env.HOME`), or can it be assumed that any directory named `/.Trash/` should behave as the system's trash?