### PR TITLE
Add File.prototype.safe{Write,Remove}Sync

### DIFF
--- a/spec/file-spec.coffee
+++ b/spec/file-spec.coffee
@@ -506,3 +506,14 @@ describe 'File', ->
         readHandler.callCount > 0
       runs ->
         expect(readHandler.argsForCall[0][0]).toBe(null)
+
+  describe 'safeWriteSync(contents)', ->
+    it 'persists the contents of the file to the specified file path', ->
+      file.safeWriteSync("contents")
+      expect(fs.readFileSync(file.getPath(), 'utf8')).toBe("contents")
+
+  describe 'safeRemoveSync()', ->
+    it 'persists the contents of the file to the specified file path', ->
+      expect(fs.existsSync(file.getPath())).toBe(true)
+      file.safeRemoveSync()
+      expect(fs.existsSync(file.getPath())).toBe(false)


### PR DESCRIPTION
Refs.: atom/atom#11794

This pull-request introduces two new methods to the `File` object, which make sure that deleting and writing to a file is flushed to disk. Moreover, they'll ask to elevate privileges in case permissions are insufficient: in particular, on Mac, it uses the `sync` command line utility to flush pending disk writes, which should (almost) be a drop-in replacement for `fdatasync` sys calls.

Writing tests for these two methods is somewhat tricky, especially for the `sync` behavior. I ended up just verifying the basic functionality of both methods, and testing this out manually on Atom following the reproduction steps provided on the aforementioned issue.