### PR TITLE
Fix typos when `runas` fails during `safeRemoveSync`

### DIFF
--- a/spec/pathwatcher-spec.coffee
+++ b/spec/pathwatcher-spec.coffee
@@ -122,9 +122,7 @@ describe 'PathWatcher', ->
         watcher = pathWatcher.watch doesNotExist, -> null
       catch error
         expect(error.message).toBe 'Unable to watch path'
-        expect(error.errno).toBe require('constants').ENOENT
-        if error.code?
-          expect(error.code).toBe 'ENOENT'
+        expect(error.code).toBe 'ENOENT'
       expect(watcher).toBe null  # ensure it threw
 
   describe 'when watching multiple files under the same directory', ->

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -403,8 +403,9 @@ class File
 
       fs.removeSync(@getPath())
       return
-    catch err
-      if err.code is 'EACCES' and process.platform is 'darwin'
+    catch error
+      if error.code is 'EACCES' and process.platform is 'darwin'
+        runas ?= require 'runas'
         # Use sync to force completion of pending disk writes.
         if runas('/bin/sync', [], admin: true) isnt 0
           throw error


### PR DESCRIPTION
This fixes an error I introduced in #107 caused by a typo when re-throwing an error in `safeRemoveSync`.