### PR TITLE
Add an empty fallback for browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "browser": "./lib/browser.js",
   "main": "./lib/main.js",
   "name": "pathwatcher",
   "description": "Watch files and directories for changes",


### PR DESCRIPTION
This PR simply adds an empty fallback for browsers. It's a step toward making `text-buffer` work with webpack, from inside browser environments. Could it be possible to merge it & release it when you have time? It would help me a lot to test my others PRs in this regard (such as https://github.com/atom/buffer-offset-index/pull/2).