### PR TITLE
Add support for watch options and windows recursive watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,25 @@ npm install pathwatcher
 PathWatcher = require 'pathwatcher'
 ```
 
-### PathWatcher.watch(filename, [listener])
+### PathWatcher.watch(filename, [options], [listener])
 
 Watch for changes on `filename`, where `filename` is either a file or a
 directory. The returned object is a `PathWatcher`.
+
+The options argument is a javascript object:
+`{ recursive: true }` will allow pathWatcher to watch a Windows directory
+recursively for any changes to files or directories under it.  This option has
+no effect on non-Windows operating systems.
 
 The listener callback gets two arguments `(event, path)`. `event` can be `rename`,
 `delete` or `change`, and `path` is the path of the file which triggered the
 event.
 
 For directories, the `change` event is emitted when a file or directory under
-the watched directory got created or deleted. And the `PathWatcher.watch` is
-not recursive, so changes of subdirectories under the watched directory would
-not be detected.
+the watched directory got created or deleted. And if the `PathWatcher.watch` is
+not recursive i.e. non-Windows operating systems or if the option has not
+been enabled on Windows, changes of subdirectories under the watched directory
+would not be detected.
 
 ### PathWatcher.close()
 

--- a/src/common.cc
+++ b/src/common.cc
@@ -122,7 +122,11 @@ NAN_METHOD(Watch) {
     return Nan::ThrowTypeError("String required");
 
   Handle<String> path = info[0]->ToString();
-  WatcherHandle handle = PlatformWatch(*String::Utf8Value(path));
+  unsigned int flags = 0;
+
+  if (info[1]->IsTrue())
+    flags |= FLAG_RECURSIVE;
+  WatcherHandle handle = PlatformWatch(*String::Utf8Value(path), flags);
   if (!PlatformIsHandleValid(handle)) {
     int error_number = PlatformInvalidHandleToErrorNumber(handle);
     v8::Local<v8::Value> err =

--- a/src/common.h
+++ b/src/common.h
@@ -24,7 +24,7 @@ typedef int32_t WatcherHandle;
 
 void PlatformInit();
 void PlatformThread();
-WatcherHandle PlatformWatch(const char* path);
+WatcherHandle PlatformWatch(const char* path, unsigned int flags_uint);
 void PlatformUnwatch(WatcherHandle handle);
 bool PlatformIsHandleValid(WatcherHandle handle);
 int PlatformInvalidHandleToErrorNumber(WatcherHandle handle);
@@ -38,6 +38,10 @@ enum EVENT_TYPE {
   EVENT_CHILD_RENAME,
   EVENT_CHILD_DELETE,
   EVENT_CHILD_CREATE,
+};
+
+enum WATCH_FLAGS {
+  FLAG_RECURSIVE = 1
 };
 
 void WaitForMainThread();

--- a/src/directory.coffee
+++ b/src/directory.coffee
@@ -307,10 +307,11 @@ class Directory
   ###
 
   subscribeToNativeChangeEvents: ->
-    @watchSubscription ?= PathWatcher.watch @path, (eventType) =>
-      if eventType is 'change'
-        @emit 'contents-changed' if Grim.includeDeprecatedAPIs
-        @emitter.emit 'did-change'
+    if not PathWatcher.isWatchedByParent @path
+      @watchSubscription ?= PathWatcher.watch @path, (eventType) =>
+        if eventType is 'change'
+          @emit 'contents-changed' if Grim.includeDeprecatedAPIs
+          @emitter.emit 'did-change'
 
   unsubscribeFromNativeChangeEvents: ->
     if @watchSubscription?

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -471,8 +471,9 @@ class File
         @emitter.emit 'did-delete'
 
   subscribeToNativeChangeEvents: ->
-    @watchSubscription ?= PathWatcher.watch @path, (args...) =>
-      @handleNativeChangeEvent(args...)
+    if not PathWatcher.isWatchedByParent @path
+      @watchSubscription ?= PathWatcher.watch @path, (args...) =>
+        @handleNativeChangeEvent(args...)
 
   unsubscribeFromNativeChangeEvents: ->
     if @watchSubscription?

--- a/src/pathwatcher_linux.cc
+++ b/src/pathwatcher_linux.cc
@@ -62,7 +62,7 @@ void PlatformThread() {
   }
 }
 
-WatcherHandle PlatformWatch(const char* path) {
+WatcherHandle PlatformWatch(const char* path, unsigned int flags_uint) {
   if (g_inotify == -1) {
     return -g_init_errno;
   }

--- a/src/pathwatcher_unix.cc
+++ b/src/pathwatcher_unix.cc
@@ -72,7 +72,7 @@ void PlatformThread() {
   }
 }
 
-WatcherHandle PlatformWatch(const char* path) {
+WatcherHandle PlatformWatch(const char* path, unsigned int flags_uint) {
   if (g_kqueue == -1) {
     return -g_init_errno;
   }


### PR DESCRIPTION
#101 These changes allow atom's tree-view package to recursively watch files and directories under a root folder on windows.