### PR TITLE
Fix race condition on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "./lib/main.js",
   "name": "pathwatcher",
   "description": "Watch files and directories for changes",
-  "version": "6.8.0",
+  "version": "6.8.0-1",
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
This pull request fixes an Access Violation exception that was occurring on Windows when closing a file handle while a `WaitForMultipleObjects` call was still in progress. As specified on MSDN, «if one of the handles is closed while the wait is still pending, the function's behavior is undefined». This was causing hard crashes on packages like the tree-view where a lot of I/O is performed in the tests.

This pull request fixes it by always closing the file handle after `WaitForMultipleObjects` returns. Now, when the user calls `.unwatch()`, we will mark the handle as "canceled", wake up `PlatformThread`, wait until it finishes waiting on all the handles (i.e. when `WaitForMultipleObjects` returns) and then delete the desired file handle in the main thread.