### PR TITLE
Enable v8 snapshot for this module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ addons:
 git:
   depth: 10
 
-node_js:
-  - "0.12"
-  - "node"
+node_js: 6
 
 env:
   - CC=gcc-4.8 CXX=g++-4.8

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "async": "~0.2.10",
     "emissary": "^1.3.2",
-    "event-kit": "^1.0.0",
+    "event-kit": "^2.1.0",
     "fs-plus": "^2.1",
     "grim": "^2.0.1",
     "iconv-lite": "~0.4.4",

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -106,14 +106,13 @@ class PathWatcher extends EventEmitter
     @handleWatcher.removeListener('change', @onChange)
     @handleWatcher.closeIfNoListener()
 
-exports.watch = (path, callback) ->
+exports.watch = (pathToWatch, callback) ->
   unless handleWatchers?
     handleWatchers = new HandleMap
     binding.setCallback (event, handle, filePath, oldFilePath) ->
       handleWatchers.get(handle).onEvent(event, filePath, oldFilePath) if handleWatchers.has(handle)
 
-  path = require('path').resolve(path)
-  new PathWatcher(path, callback)
+  new PathWatcher(path.resolve(pathToWatch), callback)
 
 exports.closeAllWatchers = ->
   if handleWatchers?

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -91,18 +91,18 @@ class PathWatcher
           @emitter.emit('did-change', {event, newFilePath})
         when 'child-rename'
           if @isWatchingParent
-            @onChange('rename', newFilePath) if @path is oldFilePath
+            @onChange({event: 'rename', newFilePath}) if @path is oldFilePath
           else
-            @onChange('change', '')
+            @onChange({event: 'change', newFilePath: ''})
         when 'child-delete'
           if @isWatchingParent
-            @onChange('delete', null) if @path is newFilePath
+            @onChange({event: 'delete', newFilePath: null}) if @path is newFilePath
           else
-            @onChange('change', '')
+            @onChange({event: 'change', newFilePath: ''})
         when 'child-change'
-          @onChange('change', '') if @isWatchingParent and @path is newFilePath
+          @onChange({event: 'change', newFilePath: ''}) if @isWatchingParent and @path is newFilePath
         when 'child-create'
-          @onChange('change', '') unless @isWatchingParent
+          @onChange({event: 'change', newFilePath: ''}) unless @isWatchingParent
 
     @disposable = @handleWatcher.onDidChange(@onChange)
 

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -1,6 +1,5 @@
 binding = require '../build/Release/pathwatcher.node'
 {HandleMap} = binding
-{EventEmitter} = require 'events'
 {Emitter} = require 'event-kit'
 fs = require 'fs'
 path = require 'path'


### PR DESCRIPTION
This pull request changes path watcher so that it can be required while generating the snapshot. To do so we have:

1. Changed `HandleWatcher` and `PathWatcher` to stop using Node's `EventEmitter` and replace it with `event-kit`.
2. Moved the `binding.setCallback` call inside the `watch` function, so that we execute it just once the first time `watch` is called.