### PR TITLE
Don't re-read the file on every change event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "main": "./lib/main.js",
+  "main": "./lib/main",
   "name": "pathwatcher",
   "description": "Watch files and directories for changes",
   "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "./lib/main",
   "name": "pathwatcher",
   "description": "Watch files and directories for changes",
-  "version": "7.1.0-0",
+  "version": "7.1.0-1",
   "licenses": [
     {
       "type": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "./lib/main",
   "name": "pathwatcher",
   "description": "Watch files and directories for changes",
-  "version": "7.0.0",
+  "version": "7.1.0-0",
   "licenses": [
     {
       "type": "MIT",

--- a/spec/file-spec.coffee
+++ b/spec/file-spec.coffee
@@ -135,19 +135,19 @@ describe 'File', ->
 
     describe "when the contents of the file change", ->
       it "notifies ::onDidChange observers", ->
-        changeHandler = jasmine.createSpy('changeHandler')
-        file.onDidChange changeHandler
-        fs.writeFileSync(file.getPath(), "this is new!")
+        lastText = null
 
-        waitsFor "change event", ->
-          changeHandler.callCount > 0
+        file.onDidChange ->
+          file.read().then (text) ->
+            lastText = text
 
-        runs ->
-          changeHandler.reset()
-          fs.writeFileSync(file.getPath(), "this is newer!")
+        runs -> fs.writeFileSync(file.getPath(), 'this is new!')
+        waitsFor 'read after first change event', -> lastText is 'this is new!'
+        runs -> expect(file.readSync()).toBe('this is new!')
 
-        waitsFor "second change event", ->
-          changeHandler.callCount > 0
+        runs -> fs.writeFileSync(file.getPath(), 'this is newer!')
+        waitsFor 'read after second change event', -> lastText is 'this is newer!'
+        runs -> expect(file.readSync()).toBe('this is newer!')
 
     describe "when the file is deleted", ->
       it "notifies ::onDidDelete observers", ->

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -428,34 +428,7 @@ class File
         @emit 'moved' if Grim.includeDeprecatedAPIs
         @emitter.emit 'did-rename'
       when 'change', 'resurrect'
-        oldContents = @cachedContents
-        handleReadError = (error) =>
-          # We cant read the file, so we GTFO on the watch
-          @unsubscribeFromNativeChangeEvents()
-
-          handled = false
-          handle = -> handled = true
-          error.eventType = eventType
-          @emitter.emit('will-throw-watch-error', {error, handle})
-          unless handled
-            newError = new Error("Cannot read file after file `#{eventType}` event: #{@path}")
-            newError.originalError = error
-            newError.code = "ENOENT"
-            newError.path
-            # I want to throw the error here, but it stops the event loop or
-            # something. No longer do interval or timeout methods get run!
-            # throw newError
-            console.error newError
-
-        try
-          handleResolve = (newContents) =>
-            unless oldContents is newContents
-              @emit 'contents-changed' if Grim.includeDeprecatedAPIs
-              @emitter.emit 'did-change'
-
-          @read(true).then(handleResolve, handleReadError)
-        catch error
-          handleReadError(error)
+        @emitter.emit 'did-change'
 
   detectResurrectionAfterDelay: ->
     _.delay (=> @detectResurrection()), 50
@@ -464,7 +437,7 @@ class File
     @exists().then (exists) =>
       if exists
         @subscribeToNativeChangeEvents()
-        @handleNativeChangeEvent('resurrect', @getPath())
+        @handleNativeChangeEvent('resurrect')
       else
         @cachedContents = null
         @emit 'removed' if Grim.includeDeprecatedAPIs

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -428,6 +428,7 @@ class File
         @emit 'moved' if Grim.includeDeprecatedAPIs
         @emitter.emit 'did-rename'
       when 'change', 'resurrect'
+        @cachedContents = null
         @emitter.emit 'did-change'
 
   detectResurrectionAfterDelay: ->


### PR DESCRIPTION
We may have been re-reading the file on every change event in order to suppress redundant change events which didn't actually affect the file's content. But for large files, loading the file's content into a string actually throws an exception. And in general, the read/transcode operation is very expensive. I think we can deal w/ redundant change events at a higher level in `text-buffer`.

Refs https://github.com/atom/atom/issues/7210