### PR TITLE
Remove privilege escalation functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "grim": "^2.0.1",
     "iconv-lite": "~0.4.4",
     "nan": "2.x",
-    "runas": "^3.1.0",
     "underscore-plus": "~1.x"
   }
 }

--- a/spec/file-spec.coffee
+++ b/spec/file-spec.coffee
@@ -506,14 +506,3 @@ describe 'File', ->
         readHandler.callCount > 0
       runs ->
         expect(readHandler.argsForCall[0][0]).toBe(null)
-
-  describe 'safeWriteSync(contents)', ->
-    it 'persists the contents of the file to the specified file path', ->
-      file.safeWriteSync("contents")
-      expect(fs.readFileSync(file.getPath(), 'utf8')).toBe("contents")
-
-  describe 'safeRemoveSync()', ->
-    it 'persists the contents of the file to the specified file path', ->
-      expect(fs.existsSync(file.getPath())).toBe(true)
-      file.safeRemoveSync()
-      expect(fs.existsSync(file.getPath())).toBe(false)


### PR DESCRIPTION
This behavior is now implemented in TextBuffer, and uses the async `spawn-as-admin` module instead of `runas`, which is synchronous.

Refs https://github.com/atom/text-buffer/pull/246