### PR TITLE
Avoid reading garbage when GetOverlappedResult succeeds w/ zero bytes

### DIFF
--- a/src/pathwatcher_win.cc
+++ b/src/pathwatcher_win.cc
@@ -153,11 +153,10 @@ void PlatformThread() {
       if (!handle || handle->canceled)
         continue;
 
-      DWORD bytes;
-      if (GetOverlappedResult(handle->dir_handle,
-                              &handle->overlapped,
-                              &bytes,
-                              FALSE) == FALSE)
+      DWORD bytes_transferred;
+      if (!GetOverlappedResult(handle->dir_handle, &handle->overlapped, &bytes_transferred, FALSE))
+        continue;
+      if (bytes_transferred == 0)
         continue;
 
       std::vector<char> old_path;


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/15223

Apparently, when listening for changes to folders on SMB drives, the [`GetOverlappedResult`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms683209(v=vs.85).aspx) API can succeed (return true) but set the `numberOfBytesTransferred` parameter to zero. Previously, our code was expecting that if `GetOverlappedResult` returned true, then there would always be at least one `FILE_NOTIFY_INFORMATION` structure to read.