### PR TITLE
Fix File.read() documentation

### DIFF
--- a/src/file.coffee
+++ b/src/file.coffee
@@ -250,7 +250,7 @@ class File
   # * `flushCache` A {Boolean} indicating whether to require a direct read or if
   #   a cached copy is acceptable.
   #
-  # Returns a promise that resolves to a String.
+  # Returns a promise that resolves to either a {String}, or null if the file does not exist.
   read: (flushCache) ->
     if @cachedContents? and not flushCache
       promise = Promise.resolve(@cachedContents)


### PR DESCRIPTION
Documentation for the return value of `File.read()` is incomplete: promise can resolve to `null` if the file in question does not exist.

Note lines 268-270:
https://github.com/atom/node-pathwatcher/blob/ea686aeffc33d99445a6480d3eafd477b8738ef8/src/file.coffee#L268-L270

For context:
https://github.com/atom/node-pathwatcher/blob/ea686aeffc33d99445a6480d3eafd477b8738ef8/src/file.coffee#L254-L272