### PR TITLE
replace Handle with Local

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -24,7 +24,7 @@ static void MakeCallbackInMainThread(uv_async_t* handle, int status) {
   Nan::HandleScope scope;
 
   if (!g_callback.IsEmpty()) {
-    Handle<String> type;
+    Local<String> type;
     switch (g_type) {
       case EVENT_CHANGE:
         type = Nan::New("change").ToLocalChecked();
@@ -52,7 +52,7 @@ static void MakeCallbackInMainThread(uv_async_t* handle, int status) {
         return;
     }
 
-    Handle<Value> argv[] = {
+    Local<Value> argv[] = {
         type,
         WatcherHandleToV8Value(g_handle),
         Nan::New(g_new_path.data(), g_new_path.size()).ToLocalChecked(),
@@ -121,7 +121,7 @@ NAN_METHOD(Watch) {
   if (!info[0]->IsString())
     return Nan::ThrowTypeError("String required");
 
-  Handle<String> path = info[0]->ToString();
+  Local<String> path = info[0]->ToString();
   WatcherHandle handle = PlatformWatch(*String::Utf8Value(path));
   if (!PlatformIsHandleValid(handle)) {
     int error_number = PlatformInvalidHandleToErrorNumber(handle);
@@ -154,7 +154,7 @@ NAN_METHOD(Unwatch) {
   Nan::HandleScope scope;
 
   if (!IsV8ValueWatcherHandle(info[0]))
-    return Nan::ThrowTypeError("Handle type required");
+    return Nan::ThrowTypeError("Local type required");
 
   PlatformUnwatch(V8ValueToWatcherHandle(info[0]));
 

--- a/src/handle_map.cc
+++ b/src/handle_map.cc
@@ -121,7 +121,7 @@ NAN_METHOD(HandleMap::Clear) {
 }
 
 // static
-void HandleMap::Initialize(Handle<Object> target) {
+void HandleMap::Initialize(Local<Object> target) {
   Nan::HandleScope scope;
 
   Local<FunctionTemplate> t = Nan::New<FunctionTemplate>(HandleMap::New);

--- a/src/handle_map.h
+++ b/src/handle_map.h
@@ -8,7 +8,7 @@
 
 class HandleMap : public Nan::ObjectWrap {
  public:
-  static void Initialize(Handle<Object> target);
+  static void Initialize(Local<Object> target);
 
  private:
   typedef std::map<WatcherHandle, NanUnsafePersistent<Value> > Map;

--- a/src/main.cc
+++ b/src/main.cc
@@ -3,7 +3,7 @@
 
 namespace {
 
-void Init(Handle<Object> exports) {
+void Init(Local<Object> exports) {
   CommonInit();
   PlatformInit();
 

--- a/src/unsafe_persistent.h
+++ b/src/unsafe_persistent.h
@@ -27,7 +27,7 @@ class NanUnsafePersistent : public NanUnsafePersistentTraits<T>::HandleType {
 template<typename T>
 NAN_INLINE void NanAssignUnsafePersistent(
     NanUnsafePersistent<T>& handle
-  , v8::Handle<T> obj) {
+  , v8::Local<T> obj) {
     handle.Reset();
     handle = NanUnsafePersistent<T>(v8::Isolate::GetCurrent(), obj);
 }
@@ -43,7 +43,7 @@ NAN_INLINE v8::Local<T> NanUnsafePersistentToLocal(const NanUnsafePersistent<T> 
 template<typename T>
 NAN_INLINE void NanAssignUnsafePersistent(
     v8::Persistent<T>& handle
-  , v8::Handle<T> obj) {
+  , v8::Local<T> obj) {
     handle.Dispose();
     handle = v8::Persistent<T>::New(obj);
 }


### PR DESCRIPTION
see https://electronjs.org/blog/nodejs-native-addons-and-electron-5

> Electron 5.0 includes a version of V8 that has finally removed v8::Handle for good, and native Node.js addons that still use it will need to be updated before they can be used with Electron 5.0.