### PR TITLE
Fix all compilation errors and warnings for Node.js 12 (V8 7.4).

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -69,7 +69,7 @@ module.exports = (grunt) ->
   grunt.registerTask('lint', ['coffeelint', 'cpplint'])
   grunt.registerTask('default', ['coffee', 'lint', 'shell:rebuild'])
   grunt.registerTask('test', ['default', 'shell:test'])
-  grunt.registerTask('prepublish', ['clean', 'coffee', 'lint', 'shell:update-atomdoc', 'atomdoc'])
+  grunt.registerTask('prepublish', ['coffee', 'lint', 'shell:update-atomdoc', 'atomdoc'])
   grunt.registerTask 'clean', ->
     rm = require('rimraf').sync
     rm 'build'

--- a/src/common.cc
+++ b/src/common.cc
@@ -24,7 +24,7 @@ static void MakeCallbackInMainThread(uv_async_t* handle, int status) {
   Nan::HandleScope scope;
 
   if (!g_callback.IsEmpty()) {
-    Handle<String> type;
+    Local<String> type;
     switch (g_type) {
       case EVENT_CHANGE:
         type = Nan::New("change").ToLocalChecked();
@@ -52,7 +52,7 @@ static void MakeCallbackInMainThread(uv_async_t* handle, int status) {
         return;
     }
 
-    Handle<Value> argv[] = {
+    Local<Value> argv[] = {
         type,
         WatcherHandleToV8Value(g_handle),
         Nan::New(g_new_path.data(), g_new_path.size()).ToLocalChecked(),
@@ -121,7 +121,7 @@ NAN_METHOD(Watch) {
   if (!info[0]->IsString())
     return Nan::ThrowTypeError("String required");
 
-  Handle<String> path = info[0]->ToString();
+  Local<String> path = info[0]->ToString();
   WatcherHandle handle = PlatformWatch(*String::Utf8Value(path));
   if (!PlatformIsHandleValid(handle)) {
     int error_number = PlatformInvalidHandleToErrorNumber(handle);
@@ -154,7 +154,7 @@ NAN_METHOD(Unwatch) {
   Nan::HandleScope scope;
 
   if (!IsV8ValueWatcherHandle(info[0]))
-    return Nan::ThrowTypeError("Handle type required");
+    return Nan::ThrowTypeError("Local type required");
 
   PlatformUnwatch(V8ValueToWatcherHandle(info[0]));
 

--- a/src/common.h
+++ b/src/common.h
@@ -18,7 +18,7 @@ bool IsV8ValueWatcherHandle(Local<Value> value);
 // Correspoding definetions on OS X and Linux.
 typedef int32_t WatcherHandle;
 #define WatcherHandleToV8Value(h) Nan::New<Integer>(h)
-#define V8ValueToWatcherHandle(v) v->Int32Value()
+#define V8ValueToWatcherHandle(v) v->Int32Value(Nan::GetCurrentContext()).FromJust()
 #define IsV8ValueWatcherHandle(v) v->IsInt32()
 #endif
 

--- a/src/handle_map.cc
+++ b/src/handle_map.cc
@@ -86,11 +86,12 @@ NAN_METHOD(HandleMap::Values) {
   HandleMap* obj = Nan::ObjectWrap::Unwrap<HandleMap>(info.This());
 
   int i = 0;
+  v8::Local<v8::Context> context = Nan::GetCurrentContext();
   v8::Local<Array> keys = Nan::New<Array>(obj->map_.size());
   for (Map::const_iterator iter = obj->map_.begin();
        iter != obj->map_.end();
        ++iter, ++i) {
-    keys->Set(i, NanUnsafePersistentToLocal(iter->second));
+    keys->Set(context, i, NanUnsafePersistentToLocal(iter->second)).FromJust();
   }
 
   info.GetReturnValue().Set(keys);
@@ -135,5 +136,8 @@ void HandleMap::Initialize(Local<Object> target) {
   Nan::SetPrototypeMethod(t, "remove", Remove);
   Nan::SetPrototypeMethod(t, "clear", Clear);
 
-  target->Set(Nan::New<String>("HandleMap").ToLocalChecked(), t->GetFunction());
+  Local<v8::Context> context = Nan::GetCurrentContext();
+  target->Set(context,
+              Nan::New<String>("HandleMap").ToLocalChecked(),
+              t->GetFunction(context).ToLocalChecked()).FromJust();
 }

--- a/src/handle_map.cc
+++ b/src/handle_map.cc
@@ -121,7 +121,7 @@ NAN_METHOD(HandleMap::Clear) {
 }
 
 // static
-void HandleMap::Initialize(Handle<Object> target) {
+void HandleMap::Initialize(Local<Object> target) {
   Nan::HandleScope scope;
 
   Local<FunctionTemplate> t = Nan::New<FunctionTemplate>(HandleMap::New);

--- a/src/handle_map.h
+++ b/src/handle_map.h
@@ -8,7 +8,7 @@
 
 class HandleMap : public Nan::ObjectWrap {
  public:
-  static void Initialize(Handle<Object> target);
+  static void Initialize(Local<Object> target);
 
  private:
   typedef std::map<WatcherHandle, NanUnsafePersistent<Value> > Map;

--- a/src/main.cc
+++ b/src/main.cc
@@ -3,7 +3,7 @@
 
 namespace {
 
-void Init(Handle<Object> exports) {
+void Init(Local<Object> exports) {
   CommonInit();
   PlatformInit();
 

--- a/src/pathwatcher_win.cc
+++ b/src/pathwatcher_win.cc
@@ -99,18 +99,20 @@ static bool QueueReaddirchanges(HandleWrapper* handle) {
 }
 
 Local<Value> WatcherHandleToV8Value(WatcherHandle handle) {
-  Local<Value> value = Nan::New(g_object_template)->NewInstance();
-  Nan::SetInternalFieldPointer(value->ToObject(), 0, handle);
+  Local<v8::Context> context = Nan::GetCurrentContext();
+  Local<Value> value = Nan::New(g_object_template)->NewInstance(context).ToLocalChecked();
+  Nan::SetInternalFieldPointer(value->ToObject(context).ToLocalChecked(), 0, handle);
   return value;
 }
 
 WatcherHandle V8ValueToWatcherHandle(Local<Value> value) {
   return reinterpret_cast<WatcherHandle>(Nan::GetInternalFieldPointer(
-      value->ToObject(), 0));
+    value->ToObject(Nan::GetCurrentContext()).ToLocalChecked(), 0));
 }
 
 bool IsV8ValueWatcherHandle(Local<Value> value) {
-  return value->IsObject() && value->ToObject()->InternalFieldCount() == 1;
+  return value->IsObject() &&
+    value->ToObject(Nan::GetCurrentContext()).ToLocalChecked()->InternalFieldCount() == 1;
 }
 
 void PlatformInit() {

--- a/src/unsafe_persistent.h
+++ b/src/unsafe_persistent.h
@@ -27,7 +27,7 @@ class NanUnsafePersistent : public NanUnsafePersistentTraits<T>::HandleType {
 template<typename T>
 NAN_INLINE void NanAssignUnsafePersistent(
     NanUnsafePersistent<T>& handle
-  , v8::Handle<T> obj) {
+  , v8::Local<T> obj) {
     handle.Reset();
     handle = NanUnsafePersistent<T>(v8::Isolate::GetCurrent(), obj);
 }
@@ -43,7 +43,7 @@ NAN_INLINE v8::Local<T> NanUnsafePersistentToLocal(const NanUnsafePersistent<T> 
 template<typename T>
 NAN_INLINE void NanAssignUnsafePersistent(
     v8::Persistent<T>& handle
-  , v8::Handle<T> obj) {
+  , v8::Local<T> obj) {
     handle.Dispose();
     handle = v8::Persistent<T>::New(obj);
 }


### PR DESCRIPTION
Depends on the work @abnerlee started in https://github.com/atom/node-pathwatcher/pull/127.

Meteor can use a fork of the `pathwatcher` package for now, but it would be great to see these changes released officially sometime soon!

Related: https://github.com/atom/watcher/pull/224#issuecomment-488084530