### PR TITLE
CI: Test package on Node v12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ addons:
 git:
   depth: 10
 
-node_js: 10
+node_js:
+  - 10
+  - 12
 
 env:
   - CC=gcc-4.8 CXX=g++-4.8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,17 @@
 image: Visual Studio 2015
 
 environment:
-  nodejs_version: "10"
+  matrix:
+    - nodejs_version: "10"
+    - nodejs_version: "12"
 
 platform:
   - x64
   - x86
 
 install:
-  - ps: Install-Product node $env:nodejs_version
+  # AppVeyor still does not support Node v12: https://github.com/appveyor/ci/issues/2921
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:PLATFORM
   - npm install
 
 test_script:

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "rimraf": "~2.2.0",
     "node-cpplint": "~0.1.5",
     "grunt-coffeelint": "git+https://github.com/atom/grunt-coffeelint.git",
-    "temp": "~0.7.0",
+    "temp": "~0.9.0",
     "grunt-atomdoc": "^1.0"
   },
   "dependencies": {

--- a/spec/file-spec.coffee
+++ b/spec/file-spec.coffee
@@ -416,7 +416,7 @@ describe 'File', ->
 
     it 'honors the specified encoding', ->
       unicodeText = 'ё'
-      unicodeBytes = new Buffer('\x51\x04') # 'ё'
+      unicodeBytes = Buffer.from('\x51\x04') # 'ё'
 
       fs.writeFileSync(file.getPath(), unicodeBytes)
 
@@ -437,7 +437,7 @@ describe 'File', ->
   describe 'createWriteStream()', ->
     it 'returns a stream to read the file', ->
       unicodeText = 'ё'
-      unicodeBytes = new Buffer('\x51\x04') # 'ё'
+      unicodeBytes = Buffer.from('\x51\x04') # 'ё'
 
       file.setEncoding('utf16le')
       stream = file.createWriteStream()
@@ -459,7 +459,7 @@ describe 'File', ->
 
     beforeEach ->
       unicodeText = 'ё'
-      unicodeBytes = new Buffer('\x51\x04') # 'ё'
+      unicodeBytes = Buffer.from('\x51\x04') # 'ё'
 
     it 'should read a file in UTF-16', ->
       fs.writeFileSync(file.getPath(), unicodeBytes)


### PR DESCRIPTION
This PR adds checks on both travis and AppVeyor for Node v12 now that this package supports it