### PR TITLE
writeSync emits did-change event [Revive]

### DIFF
--- a/spec/file-spec.coffee
+++ b/spec/file-spec.coffee
@@ -506,3 +506,10 @@ describe 'File', ->
         readHandler.callCount > 0
       runs ->
         expect(readHandler.argsForCall[0][0]).toBe(null)
+
+  describe 'writeSync()', ->
+    it 'emits did-change event', ->
+      file.onDidChange writeHandler = jasmine.createSpy('write handler')
+      file.writeSync('ok')
+      waitsFor 'write handler', ->
+        writeHandler.callCount > 0

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -322,6 +322,8 @@ class File
     @writeFileSync(@getPath(), text)
     @cachedContents = text
     @setDigest(text)
+    @emit 'contents-changed' if Grim.includeDeprecatedAPIs
+    @emitter.emit 'did-change'
     @subscribeToNativeChangeEvents() if not previouslyExisted and @hasSubscriptions()
     undefined
 


### PR DESCRIPTION
### Description of the change
Revies and closes #112
Fixes #110 

This emits 'did-change' when writeSync is used.

### Verification 
The tests are included. The CI passes.