### PR TITLE
Add 2220 and 4309 to warning list

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -33,6 +33,8 @@
             4506,  # no definition for inline function
             4577,  # 'noexcept' used with no exception handling mode specified; termination on exception is not guaranteed
             4996,  # function was declared deprecated
+            2220, # warning treated as error - no object file generated
+            4309, # 'conversion' : truncation of constant value
           ],
           'defines': [
             '_WIN32_WINNT=0x0600',


### PR DESCRIPTION
Building on win32 is failing for electron version 11.4.7. We need to add
the errors on the warning list to have a passing build on https://github.com/atom/atom/pull/22687

An altenative would be to fix the warnings. Right now there is no
capacity for us to do the fixes
